### PR TITLE
Adding dependencies to setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.txt
+prune examples/sample?/build

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ NAME = 'idem'
 PYPI_NAME = 'idemlang'
 DESC = ('')
 
+with open('requirements.txt') as f:
+    REQUIREMENTS = f.read().splitlines()
+
 # Version info -- read without importing
 _locals = {}
 with open('{}/version.py'.format(NAME)) as fp:
@@ -53,6 +56,7 @@ setup(name=PYPI_NAME,
       url='',
       version=VERSION,
       description=DESC,
+      install_requires=REQUIREMENTS,
       classifiers=[
           'Operating System :: OS Independent',
           'Programming Language :: Python',


### PR DESCRIPTION
We also need the MANIFEST.in for sdist packages, otherwise requirements.txt won't be in the tarball.